### PR TITLE
Update to support later nodejs versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+2.0.1
+---
+- Removed the max range limiter for nodejs version
+- Removed the max range limiter for bluebird version
+
 2.0.0
 - Updated to use bluebird 3.x and support node 5
 - Removed Cancelation feature because Bluebird v3 changed it and I'm not quite sure how

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "bluebird-events",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A wrapper around event emitters that returns a bluerbird promise resolved or rejected when certain events are fired.",
   "main": "index.js",
   "engines": {
-    "node": ">=0.10 <6.x"
+    "node": ">=0.10"
   },
   "scripts": {
     "test": "./node_modules/.bin/grunt test"
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/L7Labs/bluebird-events",
   "dependencies": {},
   "peerDependencies": {
-    "bluebird": ">=2.x <4.x"
+    "bluebird": ">=2.x"
   },
   "devDependencies": {
     "bluebird": "^3.3.0",


### PR DESCRIPTION
- Removed the max range limiter for nodejs version
- Removed the max range limiter for bluebird version
- Updated changelog